### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-slick",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "main": "dist/slick.js",
   "ignore": [
     "app",
@@ -20,7 +20,7 @@
   ],
   "dependencies": {
     "angular": "~1.3.13",
-    "slick-carousel": "~1.3.15"
+    "slick-carousel": "~1.4.1"
   },
   "author": {
     "name": "Vasyl Stanislavchuk"


### PR DESCRIPTION
1.3.15 carousel is bugged (slick.scss has "image-url($url, false, false)" and after compiling it shows too many arguments (3 for 1)) it disallows to correctly deploy app.

Also, maybe update angular version?
